### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/assets/javascripts/category_form.js
+++ b/app/assets/javascripts/category_form.js
@@ -70,7 +70,7 @@ $(function(){
       $.ajax({
         url: '/items/category_search',
         type: 'GET',
-        // postsコントローラーにparamsをchildren_idで送る
+        // itemsコントローラーにparamsをchildren_idで送る
         data: { children_id: childValue },
         dataType: 'json'
       })

--- a/app/assets/javascripts/item_new.js
+++ b/app/assets/javascripts/item_new.js
@@ -34,6 +34,19 @@ $(function(){
     $('.label-content').css('width', labelWidth);
   }
 
+  // 画像が１つ以上あるか確認
+  function checkImage() {
+    // プレビューに画像があるか確認
+    var imagecount = $('.preview-box').length;
+    // 画像がない場合→送信ボタンの効力無効
+    if (imagecount == 0) {
+      $('.form__main__content__send-boxes__send-btn').prop("disabled", true);
+      $('.form__main__content__send-boxes__send-btn').css('background-color','#808080');
+    } else {
+      $('.form__main__content__send-boxes__send-btn').prop("disabled", false);
+      $('.form__main__content__send-boxes__send-btn').css('background-color','');
+    }
+  }
   // 投稿編集時
     //items/:i/editページへリンクした際のアクション=======================================
     if (window.location.href.match(/\/items\/\d+\/edit/)){
@@ -45,10 +58,6 @@ $(function(){
       $('.preview-box').each(function(index, box){
         $(box).attr('id', `preview-box__${index}`);
       })
-      // //削除ボタンにidを追加
-      // $('.preview-box__lower-box__delete-box').each(function(index, box){
-      //   $(box).attr('id', `delete_btn_${index}`);
-      // })
       //削除ボタンにidを追加
       $('.preview-box__lower-box__delete-box-hidden').each(function(index, box){
         $(box).attr('id', `delete_btn_${index}`);
@@ -58,15 +67,21 @@ $(function(){
       if (count == 5) {
         $('.label-content').hide();
       }
-      // 手数料表示
+      // 手数料再表示
       let tax = $('#item_price').val();
       $('.form__main__content__settlement__commission-box__money01').text(Math.ceil(tax * 0.1) + "円");
       $('.form__main__content__settlement__commission-box__money02').text(Math.ceil(tax - (tax * 0.1)) + "円");
+      // 画像が１つ以上あるか確認
+      checkImage();
     }
     //=============================================================================
 
+  // はじめに画像が１つ以上あるか確認
+  checkImage();
+  
   // プレビューの追加
   $(document).on('change', '.hidden-field', function() {
+    // ラベル幅調整
     setLabel();
     //hidden-fieldのidの数値のみ取得
     var id = $(this).attr('id').replace(/[^0-9]/g, '');
@@ -134,18 +149,13 @@ $(function(){
         if (count == 5) { 
           $('.label-content').hide();
         }
-
-        //編集時の動作　プレビュー削除したフィールドにdestroy用のチェックボックスがあった場合、チェックを外す=============
-        // if ($(`#item_images_attributes_${id}__destroy`)){
-        //   $(`#item_images_attributes_${id}__destroy`).prop('checked',false);
-        // } 
-
+        
+        //編集時の動作 プレビュー削除したフィールドにdestroy用のチェックボックスがあった場合、チェックを外す
         if ($(`#item_images_attributes_${id}__destroy`).length != 0) {
           $(`#item_images_attributes_${id}__destroy`).prop('checked',false);
         }
-        //=============================================================================
 
-        //ラベルのwidth操作
+        // ラベル幅調整
         setLabel();
         //ラベルのidとforの値を変更
         if(count < 5){
@@ -153,10 +163,12 @@ $(function(){
           $('.label-box').attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_image`});
         }
       }
+    // 画像が１つ以上あるか確認
+    checkImage();
     };
   });
 
-  // 画像削除時の動作
+  // 新しく投稿した画像削除時の動作
   $(document).on('click', '.preview-box__lower-box__delete-box', function() {
     //item_images_attributes_${id}_image から${id}に入った数字のみを抽出
     var id = $(this).attr('id').replace(/[^0-9]/g, '');
@@ -199,22 +211,6 @@ $(function(){
       });
     });
 
-    // // hidden-checkboxのid振り直し
-    // $(function(){
-    //   $('.hidden-checkbox').attr('id', function(i) {
-    //     return 'item_images_attributes_' + i + '__destroy';
-    //     i++;
-    //   });
-    // });
-
-    // // hidden-checkboxのname振り直し
-    // $(function(){
-    //   $('.hidden-checkbox').attr('name', function(i) {
-    //     return 'item[images_attributes][' + i + '][_destroy]';
-    //     i++;
-    //   });
-    // });
-
     //削除時のラベル操作
     var count = $('.preview-box').length;
     $('.label-box').attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_image`});
@@ -223,11 +219,13 @@ $(function(){
     if (count == 4) {
       $('.label-content').show();
     }
-
+    // ラベル幅調整
     setLabel(count);
+    // 画像が１つ以上あるか確認
+    checkImage();
   });
 
-  // 画像削除時の動作
+  // 編集時元々あった画像削除時の動作
   $(document).on('click', '.preview-box__lower-box__delete-box-hidden', function() {
     // item_images_attributes_${id}_image から${id}に入った数字のみを抽出
     var id = $(this).attr('id').replace(/[^0-9]/g, '');
@@ -239,59 +237,9 @@ $(function(){
 
     // 取得したidに該当するプレビューを削除
     $(`#preview-box__${id}`).remove();
-    // $(`#preview-box__${id}`).val("");
 
-    // フォームを削除 
-    // $(`#item_images_attributes_${id}_image`).remove();
+    // フォームの値をクリア（削除はしない）
     $(`#item_images_attributes_${id}_image`).val("");
-
-    // preview-boxのid振り直し
-    // $(function(){
-    //   $('.preview-box').attr('id', function(i) {
-    //     return 'preview-box__' + i;
-    //     i++;
-    //   });
-    // });
-
-    // // hidden-fieldのid振り直し
-    // $(function(){
-    //   $('.hidden-field').attr('id', function(i) {
-    //     return 'item_images_attributes_' + i + '_image';
-    //     i++;
-    //   });
-    // });
-
-    // // hidden-fieldのname振り直し
-    // $(function(){
-    //   $('.hidden-field').attr('name', function(i) {
-    //     return 'item[images_attributes][' + i + '][image]';
-    //     i++;
-    //   });
-    // });
-
-    // // 削除ボタンのid振り直し
-    // $(function(){
-    //   $('.preview-box__lower-box__delete-box').attr('id', function(i) {
-    //     return 'delete_btn_' + i;
-    //     i++;
-    //   });
-    // });
-
-    // // hidden-checkboxのid振り直し
-    // $(function(){
-    //   $('.hidden-checkbox').attr('id', function(i) {
-    //     return 'item_images_attributes_' + i + '__destroy';
-    //     i++;
-    //   });
-    // });
-
-    // // hidden-checkboxのname振り直し
-    // $(function(){
-    //   $('.hidden-checkbox').attr('name', function(i) {
-    //     return 'item[images_attributes][' + i + '][_destroy]';
-    //     i++;
-    //   });
-    // });
 
     //削除時のラベル操作
     var count = $('.preview-box').length;
@@ -301,8 +249,9 @@ $(function(){
     if (count == 4) {
       $('.label-content').show();
     }
-
+    // ラベル幅調整
     setLabel(count);
+    // 画像が１つ以上あるか確認
+    checkImage();
   });
-  
 });

--- a/app/assets/javascripts/item_new.js
+++ b/app/assets/javascripts/item_new.js
@@ -42,9 +42,11 @@ $(function(){
     if (imagecount == 0) {
       $('.form__main__content__send-boxes__send-btn').prop("disabled", true);
       $('.form__main__content__send-boxes__send-btn').css('background-color','#808080');
+      $('.form__main__content__send-boxes__image-error').css('display', '');
     } else {
       $('.form__main__content__send-boxes__send-btn').prop("disabled", false);
       $('.form__main__content__send-boxes__send-btn').css('background-color','');
+      $('.form__main__content__send-boxes__image-error').css('display', 'none');
     }
   }
   // 投稿編集時

--- a/app/assets/javascripts/item_new.js
+++ b/app/assets/javascripts/item_new.js
@@ -34,14 +34,75 @@ $(function(){
     $('.label-content').css('width', labelWidth);
   }
 
-  // file番号の定義
-  let fileIndex = [1,2,3,4,5];
+  // 投稿編集時
+    //items/:i/editページへリンクした際のアクション=======================================
+    if (window.location.href.match(/\/items\/\d+\/edit/)){
+      //登録済み画像のプレビュー表示欄の要素を取得する
+      var prevContent = $('.label-content').prev();
+      labelWidth = (620 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
+      $('.label-content').css('width', labelWidth);
+      //プレビューにidを追加
+      $('.preview-box').each(function(index, box){
+        $(box).attr('id', `preview-box__${index}`);
+      })
+      // //削除ボタンにidを追加
+      // $('.preview-box__lower-box__delete-box').each(function(index, box){
+      //   $(box).attr('id', `delete_btn_${index}`);
+      // })
+      //削除ボタンにidを追加
+      $('.preview-box__lower-box__delete-box-hidden').each(function(index, box){
+        $(box).attr('id', `delete_btn_${index}`);
+      })
+      var count = $('.preview-box').length;
+      //プレビューが5あるときは、投稿ボックスを消しておく
+      if (count == 5) {
+        $('.label-content').hide();
+      }
+      // 手数料表示
+      let tax = $('#item_price').val();
+      $('.form__main__content__settlement__commission-box__money01').text(Math.ceil(tax * 0.1) + "円");
+      $('.form__main__content__settlement__commission-box__money02').text(Math.ceil(tax - (tax * 0.1)) + "円");
+    }
+    //=============================================================================
 
   // プレビューの追加
   $(document).on('change', '.hidden-field', function() {
     setLabel();
     //hidden-fieldのidの数値のみ取得
     var id = $(this).attr('id').replace(/[^0-9]/g, '');
+
+    // preview-boxのid振り直し
+    $(function(){
+      $('.preview-box').attr('id', function(i) {
+        return 'preview-box__' + i;
+        i++;
+      });
+    });
+
+    // hidden-fieldのid振り直し
+    $(function(){
+      $('.hidden-field').attr('id', function(i) {
+        return 'item_images_attributes_' + i + '_image';
+        i++;
+      });
+    });
+
+    // hidden-fieldのname振り直し
+    $(function(){
+      $('.hidden-field').attr('name', function(i) {
+        return 'item[images_attributes][' + i + '][image]';
+        i++;
+      });
+    });
+
+    // 削除ボタンのid振り直し
+    $(function(){
+      $('.preview-box__lower-box__delete-box').attr('id', function(i) {
+        return 'delete_btn_' + i;
+        i++;
+      });
+    });
+
     //labelボックスのidとforを更新
     $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_image`});
     //選択したfileのオブジェクトを取得
@@ -60,49 +121,188 @@ $(function(){
         var prevContent = $('.label-content').prev();
         $(prevContent).append(html);
 
-        $('.hidden-content').append(buildInputImage(fileIndex[0]));
-        fileIndex.shift();
-      }
-      //イメージを追加
-      $(`#preview-box__${id} img`).attr('src', `${image}`);
-      var count = $('.preview-box').length;
-      //プレビューが5個あったらラベルを隠す 
-      if (count == 5) { 
-        $('.label-content').hide();
-      }
+        // 画像投稿投稿フォルダを追加する
+        var hiddenCount = $('.hidden-field').length;
+        if (hiddenCount < 6) {
+          $('.hidden-content').append(buildInputImage(hiddenCount));
+        }
+      
+        //イメージを追加
+        $(`#preview-box__${id} img`).attr('src', `${image}`);
+        var count = $('.preview-box').length;
+        //プレビューが5個あったらラベルを隠す 
+        if (count == 5) { 
+          $('.label-content').hide();
+        }
 
-      //ラベルのwidth操作
-      setLabel();
-      //ラベルのidとforの値を変更
-      if(count < 5){
-        //プレビューの数でラベルのオプションを更新する
-        $('.label-box').attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_image`});
+        //編集時の動作　プレビュー削除したフィールドにdestroy用のチェックボックスがあった場合、チェックを外す=============
+        // if ($(`#item_images_attributes_${id}__destroy`)){
+        //   $(`#item_images_attributes_${id}__destroy`).prop('checked',false);
+        // } 
+
+        if ($(`#item_images_attributes_${id}__destroy`).length != 0) {
+          $(`#item_images_attributes_${id}__destroy`).prop('checked',false);
+        }
+        //=============================================================================
+
+        //ラベルのwidth操作
+        setLabel();
+        //ラベルのidとforの値を変更
+        if(count < 5){
+          //プレビューの数でラベルのオプションを更新する
+          $('.label-box').attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_image`});
+        }
       }
-    }
+    };
   });
 
-  // 画像の削除
+  // 画像削除時の動作
   $(document).on('click', '.preview-box__lower-box__delete-box', function() {
-    var count = $('.preview-box').length;
-    setLabel(count);
     //item_images_attributes_${id}_image から${id}に入った数字のみを抽出
     var id = $(this).attr('id').replace(/[^0-9]/g, '');
+
     //取得したidに該当するプレビューを削除
     $(`#preview-box__${id}`).remove();
-    //フォームの中身を削除 
-    $(`#item_images_attributes_${id}_image`).val("");
+
+    //フォームを削除 
+    $(`#item_images_attributes_${id}_image`).remove();
+
+    // preview-boxのid振り直し
+    $(function(){
+      $('.preview-box').attr('id', function(i) {
+        return 'preview-box__' + i;
+        i++;
+      });
+    });
+
+    // hidden-fieldのid振り直し
+    $(function(){
+      $('.hidden-field').attr('id', function(i) {
+        return 'item_images_attributes_' + i + '_image';
+        i++;
+      });
+    });
+
+    // hidden-fieldのname振り直し
+    $(function(){
+      $('.hidden-field').attr('name', function(i) {
+        return 'item[images_attributes][' + i + '][image]';
+        i++;
+      });
+    });
+
+    // 削除ボタンのid振り直し
+    $(function(){
+      $('.preview-box__lower-box__delete-box').attr('id', function(i) {
+        return 'delete_btn_' + i;
+        i++;
+      });
+    });
+
+    // // hidden-checkboxのid振り直し
+    // $(function(){
+    //   $('.hidden-checkbox').attr('id', function(i) {
+    //     return 'item_images_attributes_' + i + '__destroy';
+    //     i++;
+    //   });
+    // });
+
+    // // hidden-checkboxのname振り直し
+    // $(function(){
+    //   $('.hidden-checkbox').attr('name', function(i) {
+    //     return 'item[images_attributes][' + i + '][_destroy]';
+    //     i++;
+    //   });
+    // });
 
     //削除時のラベル操作
     var count = $('.preview-box').length;
+    $('.label-box').attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_image`});
+    
     //5個めが消されたらラベルを表示
     if (count == 4) {
       $('.label-content').show();
     }
-    setLabel(count);
 
-    if(id < 5){
-      //削除された際に、空っぽになったfile_fieldをもう一度入力可能にする
-      $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_image`});
-    }
+    setLabel(count);
   });
+
+  // 画像削除時の動作
+  $(document).on('click', '.preview-box__lower-box__delete-box-hidden', function() {
+    // item_images_attributes_${id}_image から${id}に入った数字のみを抽出
+    var id = $(this).attr('id').replace(/[^0-9]/g, '');
+    
+    // 投稿編集時
+    if ($(`#item_images_attributes_${id}__destroy`).length != 0) {
+      $(`#item_images_attributes_${id}__destroy`).prop('checked',true);
+    }
+
+    // 取得したidに該当するプレビューを削除
+    $(`#preview-box__${id}`).remove();
+    // $(`#preview-box__${id}`).val("");
+
+    // フォームを削除 
+    // $(`#item_images_attributes_${id}_image`).remove();
+    $(`#item_images_attributes_${id}_image`).val("");
+
+    // preview-boxのid振り直し
+    // $(function(){
+    //   $('.preview-box').attr('id', function(i) {
+    //     return 'preview-box__' + i;
+    //     i++;
+    //   });
+    // });
+
+    // // hidden-fieldのid振り直し
+    // $(function(){
+    //   $('.hidden-field').attr('id', function(i) {
+    //     return 'item_images_attributes_' + i + '_image';
+    //     i++;
+    //   });
+    // });
+
+    // // hidden-fieldのname振り直し
+    // $(function(){
+    //   $('.hidden-field').attr('name', function(i) {
+    //     return 'item[images_attributes][' + i + '][image]';
+    //     i++;
+    //   });
+    // });
+
+    // // 削除ボタンのid振り直し
+    // $(function(){
+    //   $('.preview-box__lower-box__delete-box').attr('id', function(i) {
+    //     return 'delete_btn_' + i;
+    //     i++;
+    //   });
+    // });
+
+    // // hidden-checkboxのid振り直し
+    // $(function(){
+    //   $('.hidden-checkbox').attr('id', function(i) {
+    //     return 'item_images_attributes_' + i + '__destroy';
+    //     i++;
+    //   });
+    // });
+
+    // // hidden-checkboxのname振り直し
+    // $(function(){
+    //   $('.hidden-checkbox').attr('name', function(i) {
+    //     return 'item[images_attributes][' + i + '][_destroy]';
+    //     i++;
+    //   });
+    // });
+
+    //削除時のラベル操作
+    var count = $('.preview-box').length;
+    $('.label-box').attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_image`});
+    
+    //5個めが消されたらラベルを表示
+    if (count == 4) {
+      $('.label-content').show();
+    }
+
+    setLabel(count);
+  });
+  
 });

--- a/app/assets/stylesheets/item_new.scss
+++ b/app/assets/stylesheets/item_new.scss
@@ -126,10 +126,10 @@
           //file_fieldのcss
           .hidden-content {
             .hidden-field {
-              // display: none;
+              display: none;
             }
             .hidden-checkbox {
-              // display: none;
+              display: none;
             }
           }
 

--- a/app/assets/stylesheets/item_new.scss
+++ b/app/assets/stylesheets/item_new.scss
@@ -76,6 +76,15 @@
                   background: #f5f5f5;
                   cursor: pointer;
                 }
+                &__delete-box-hidden {
+                  color: #00b0ff;
+                  width: 50%;
+                  height: 50px;
+                  line-height: 50px;
+                  border: 1px solid #eee;
+                  background: #f5f5f5;
+                  cursor: pointer;
+                }
               }
             }
           }
@@ -117,10 +126,10 @@
           //file_fieldのcss
           .hidden-content {
             .hidden-field {
-              display: none;
+              // display: none;
             }
             .hidden-checkbox {
-              display: none;
+              // display: none;
             }
           }
 

--- a/app/assets/stylesheets/item_new.scss
+++ b/app/assets/stylesheets/item_new.scss
@@ -347,6 +347,12 @@
         height: 200px;
         margin: 0px 145px;
         
+        &__image-error {
+          text-align: center;
+          font-size: 12px;
+          margin-bottom: 5px;
+          color: red;
+        }
         &__send-btn {
           width: 100%;
           height: 50px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,27 @@ class ItemsController < ApplicationController
   def edit
   end
 
+  def update
+    if @item.user_id == current_user.id
+      if item_params[:images_attributes].nil?
+        flash.now[:alert] = '画像がありません'
+        render :edit
+      else
+        if @item.valid?
+          if @item.update(item_params)
+            redirect_to item_path(@item.id), notice: '商品情報を更新しました'
+          else
+            render :edit
+          end
+        else
+          render :edit
+        end
+      end
+    else
+      render :edit
+    end
+  end
+
   def destroy
     if @item.destroy
       redirect_to root_path, notice: '削除しました'
@@ -91,7 +112,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :price, :describe, :category_id, :brand, :buyer_id, :condition_id, :shipping_charge_id, :prefecture_id, :delivery_date_id, images_attributes: [:image]).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :price, :describe, :category_id, :brand, :buyer_id, :condition_id, :shipping_charge_id, :prefecture_id, :delivery_date_id, images_attributes: [:image, :_destroy, :id]).merge(user_id: current_user.id)
   end
 
   def set_parents

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   require "payjp"
-  before_action :set_item, only: [:show, :edit, :destroy]
-  before_action :set_parents, only: [:new, :create, :edit]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :set_parents, only: [:new, :create, :edit, :update]
+  before_action :set_edit_category, only: [:edit, :update]
 
   def index
     @items = Item.includes(:images).order('created_at DESC').limit(5)
@@ -101,4 +102,30 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def set_edit_category
+    # ▼ ①ここで該当商品の子・孫カテゴリーを変数へ代入
+    grandchild = @item.category
+    child = grandchild.parent
+    # if @category_id == 46 or @category_id == 74 or @category_id == 134 or @category_id == 142 or @category_id == 147 or @category_id == 150 or @category_id == 158
+    # else
+    # @category_parent_array = Category.where(ancestry: nil)
+    # ② ▼ 親カテゴリーのnameとidを配列代入
+    @parent_array = []
+    @parent_array << @item.category.parent.parent.name
+    @parent_array << @item.category.parent.parent.id
+    # end
+    # ③ ▼ 子カテゴリーを全てインスタンス変数へ代入
+    @category_children_array = Category.where(ancestry: child.ancestry)
+    # ④ ▼ 子カテゴリーのnameとidを配列代入
+    @child_array = []
+    @child_array << child.name # ⑤で生成した変数を元にname・idを取得
+    @child_array << child.id
+    # ⑤ ▼ 孫カテゴリーを全てインスタンス変数へ代入
+    @category_grandchildren_array = Category.where(ancestry: grandchild.ancestry) 
+    # ⑥ ▼ 孫カテゴリーのnameとidを配列代入
+    @grandchild_array = []
+    @grandchild_array << grandchild.name # ⑤で生成した変数を元にname・idを取得
+    @grandchild_array << grandchild.id
+  end
+  
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,19 +38,14 @@ class ItemsController < ApplicationController
 
   def update
     if @item.user_id == current_user.id
-      if item_params[:images_attributes].nil?
-        flash.now[:alert] = '画像がありません'
-        render :edit
-      else
-        if @item.valid?
-          if @item.update(item_params)
-            redirect_to item_path(@item.id), notice: '商品情報を更新しました'
-          else
-            render :edit
-          end
+      if @item.valid?
+        if @item.update(item_params)
+          redirect_to item_path(@item.id), notice: '商品情報を更新しました'
         else
           render :edit
         end
+      else
+        render :edit
       end
     else
       render :edit
@@ -124,28 +119,24 @@ class ItemsController < ApplicationController
   end
 
   def set_edit_category
-    # ▼ ①ここで該当商品の子・孫カテゴリーを変数へ代入
+    # 該当商品の子・孫カテゴリーを変数へ代入
     grandchild = @item.category
     child = grandchild.parent
-    # if @category_id == 46 or @category_id == 74 or @category_id == 134 or @category_id == 142 or @category_id == 147 or @category_id == 150 or @category_id == 158
-    # else
-    # @category_parent_array = Category.where(ancestry: nil)
-    # ② ▼ 親カテゴリーのnameとidを配列代入
+    # 親カテゴリーのnameとidを配列代入
     @parent_array = []
     @parent_array << @item.category.parent.parent.name
     @parent_array << @item.category.parent.parent.id
-    # end
-    # ③ ▼ 子カテゴリーを全てインスタンス変数へ代入
+    # 子カテゴリーを全てインスタンス変数へ代入
     @category_children_array = Category.where(ancestry: child.ancestry)
-    # ④ ▼ 子カテゴリーのnameとidを配列代入
+    # 子カテゴリーのnameとidを配列代入
     @child_array = []
-    @child_array << child.name # ⑤で生成した変数を元にname・idを取得
+    @child_array << child.name
     @child_array << child.id
-    # ⑤ ▼ 孫カテゴリーを全てインスタンス変数へ代入
+    # 孫カテゴリーを全てインスタンス変数へ代入
     @category_grandchildren_array = Category.where(ancestry: grandchild.ancestry) 
-    # ⑥ ▼ 孫カテゴリーのnameとidを配列代入
+    # 孫カテゴリーのnameとidを配列代入
     @grandchild_array = []
-    @grandchild_array << grandchild.name # ⑤で生成した変数を元にname・idを取得
+    @grandchild_array << grandchild.name
     @grandchild_array << grandchild.id
   end
   

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -32,12 +32,8 @@ class ItemsController < ApplicationController
 
   def update
     if @item.user_id == current_user.id
-      if @item.valid?
-        if @item.update(item_params)
-          redirect_to item_path(@item.id), notice: '商品情報を更新しました'
-        else
-          render :edit
-        end
+      if @item.valid? && @item.update(item_params)
+        redirect_to item_path(@item.id), notice: '商品情報を更新しました'
       else
         render :edit
       end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,18 +16,12 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.new(item_params)
-    if @item.images.present?
-      if @item.save
-        redirect_to root_path, notice: '出品完了しました'
-      else
-        flash.now[:alert] = '未記入の必須項目もしくは条件を満たしていない項目があります'
-        render :new
-      end
+    if @item.save
+      redirect_to root_path, notice: '出品完了しました'
     else
-      redirect_to new_item_path
-      flash[:alert] = "画像を入れてください"
+      flash.now[:alert] = '未記入の必須項目もしくは条件を満たしていない項目があります'
+      render :new
     end
-    
   end
 
   def show
@@ -48,7 +42,8 @@ class ItemsController < ApplicationController
         render :edit
       end
     else
-      render :edit
+      flash.now[:alert] = 'ログインし直して下さい'
+      redirect_to root_path
     end
   end
 

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -121,6 +121,8 @@
                 %span.form__main__content__settlement__commission-box__money02
               
         .form__main__content__send-boxes
+          .form__main__content__send-boxes__image-error
+            画像を1枚以上入れて下さい
           = f.submit "出品する", class: "form__main__content__send-boxes__send-btn"
           = link_to root_path, class: "form__main__content__send-boxes__return-btn" do
             = 'もどる'

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -15,14 +15,28 @@
 
           .form__main__content__upload__container
             .prev-content
+              - @item.images.each do |image|
+                .preview-box
+                  .preview-box__upper-box
+                    = image_tag image.image.url, width: "114", height: "80", alt: "preview"
+                  .preview-box__lower-box
+                    .preview-box__lower-box__update-box
+                      %label.edit-btn 編集
+                    .preview-box__lower-box__delete-box-hidden
+                      .delete-btn
+                        %span 削除
+
             .label-content
-              %label{for: "item_images_attributes_0_image", class: "label-box", id: "label-box--0"}
+              = f.label :"images_attributes_#{@item.images.length}_image", class: "label-box", id: "label-box--#{@item.images.length}" do
                 %pre.label-box__text-visible クリックしてファイルをアップロード
                 .label-box__icon
                   = icon('fa', 'camera')
+
             .hidden-content
               = f.fields_for :images do |i|
-                = i.file_field :image, class: "hidden-field", name: "item[images_attributes][#{i.index}][image]"
+                = i.file_field :image, class: "hidden-field"
+                = i.check_box :_destroy, class: "hidden-checkbox"
+              %input{name: "item[images_attributes][#{@item.images.length}][image]", id: "item_images_attributes_#{@item.images.length}_image", class:"hidden-field", type:"file"}
 
         .form__main__content__sell
           .form__main__content__sell__form

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -137,8 +137,10 @@
                 %span.form__main__content__settlement__commission-box__money02
 
         .form__main__content__send-boxes
+          .form__main__content__send-boxes__image-error
+            画像を1枚以上入れて下さい
           = f.submit "変更する", class: "form__main__content__send-boxes__send-btn"
-          = link_to root_path, class: "form__main__content__send-boxes__return-btn" do
+          = link_to item_path(@item.id), class: "form__main__content__send-boxes__return-btn" do
             = 'もどる'
           .form__main__content__send-boxes__note
             禁止されている行為および出品物を必ずご確認ください。偽ブランド品や盗品物などの販売は犯罪であり、法律により処罰される可能性があります。また、出品をもちまして加盟店規約に同意したことになります。

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,1 +1,143 @@
-%h1 Edit page
+.form
+  .form__main
+    = form_with model: @item, local: true do |f|
+      .form__main__head
+        = link_to root_path do
+          = image_tag 'logo/logo.png', alt: 'FURIMAロゴ', class: 'logo' 
+      .form__main__content
+        .form__main__content__upload
+          .form__main__content__title
+            出品画像
+            %span.form__main__content__require
+              必須
+        .form__main__content__p
+          最大5枚までアップロードできます
+
+          .form__main__content__upload__container
+            .prev-content
+            .label-content
+              %label{for: "item_images_attributes_0_image", class: "label-box", id: "label-box--0"}
+                %pre.label-box__text-visible クリックしてファイルをアップロード
+                .label-box__icon
+                  = icon('fa', 'camera')
+            .hidden-content
+              = f.fields_for :images do |i|
+                = i.file_field :image, class: "hidden-field", name: "item[images_attributes][#{i.index}][image]"
+
+        .form__main__content__sell
+          .form__main__content__sell__form
+            .form__main__content__title
+              = f.label :name, "商品名"
+              %span.form__main__content__require
+                必須
+            = f.text_field :name, placeholder: "　商品名（必須 40文字まで)", class: "form__main__content__sell__form__name"
+
+          .form__main__content__sell__form
+            .form__main__content__title
+              = f.label :describe, "商品の説明"
+              %span.form__main__content__require
+                必須
+            = f.text_area :describe, placeholder: "　商品の説明（必須 1,000文字以内)", class: "form__main__content__sell__form__describe"
+
+        .form__main__content__describe
+          %h3.show-sub-head
+            商品の詳細
+          .form__main__content__describe__form
+            .form__main__content__form-group
+              .form__main__content__title
+                = f.label :category, "カテゴリー"
+                %span.form__main__content__require
+                  必須
+              #category_field
+                = f.collection_select :category_id, @parents, :id, :name, { selected: @parent_array }, class: "form__main__content__describe__category", id: "category_form"
+                = f.collection_select :category_id, @category_children_array, :id, :name, { selected: @child_array }, class: "child_category_id", id: "child_category_id"
+                = f.collection_select :category_id, @category_grandchildren_array, :id, :name, { selected: @grandchild_array }, class: "grandchild_category_id", id: "grandchild_category_id"
+
+            .form__main__content__form-group
+              .form__main__content__title
+                = f.label :brand, "ブランド"
+                %span.form__main__content__option
+                  任意
+              = f.text_field :brand, placeholder: "　例）シャネル", class: "form__main__content__describe__brand"
+
+            .form__main__content__form-group
+              .form__main__content__title
+                = f.label :condition, "商品の状態"
+                %span.form__main__content__require
+                  必須
+              .form__main__content__select-box
+                = f.collection_select(:condition_id, Condition.all, :id, :condition, {include_blank: "選択してください"}, {class: "form__main__content__describe__condition", id: "condition-box"})
+
+        .form__main__content__delivery
+          %h3.show-sub-head
+            配送について
+          .form__main__content__delivery__form
+            .form__main__content__form-group
+              .form__main__content__title
+                = f.label :defrayer, "配送料の負担"
+                %span.form__main__content__require
+                  必須
+              .form__main__content__select-box
+                = f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :defrayer, {include_blank: "選択してください"}, {class: "form__main__content__delivery__shipping_charge", id: "shipping_charge-box"})
+
+            .form__main__content__form-group
+              .form__main__content__title
+                = f.label :name, "発送元の地域"
+                %span.form__main__content__require
+                  必須
+              .form__main__content__select-box
+                = f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {include_blank: "選択してください"}, {class: "form__main__content__delivery__prefecture", id: "prefecure-box"})
+
+            .form__main__content__form-group
+              .form__main__content__title
+                = f.label :date, "発送までの日数"
+                %span.form__main__content__require
+                  必須
+              .form__main__content__select-box
+                = f.collection_select(:delivery_date_id, DeliveryDate.all, :id, :date, {include_blank: "選択してください"}, {class: "form__main__content__delivery__date", id: "delivery_date-box"})
+
+        .form__main__content__settlement
+          %h3.show-sub-head
+            価格（¥300~9,999,999)
+          .form__main__content__settlement__form
+            .form__main__content__settlement__input-price
+              .form__main__content__title
+                = f.label :price, "販売価格"
+                %span.form__main__content__require
+                  必須
+              %span.form__main__content__settlement__doll-mark
+                ¥
+              .form__main__content__settlement__price-form
+                = f.number_field :price, placeholder: "0", class: "form__main__content__settlement__price-form", id: "item_price"
+
+            .form__main__content__settlement__commission-up
+              .form__main__content__settlement__commission-box
+                %div
+                  販売手数料（10%）
+                %span.form__main__content__settlement__commission-box__money01
+
+            .form__main__content__settlement__commission-down
+              .form__main__content__settlement__commission-box
+                %div
+                  販売利益
+                %span.form__main__content__settlement__commission-box__money02
+
+        .form__main__content__send-boxes
+          = f.submit "変更する", class: "form__main__content__send-boxes__send-btn"
+          = link_to root_path, class: "form__main__content__send-boxes__return-btn" do
+            = 'もどる'
+          .form__main__content__send-boxes__note
+            禁止されている行為および出品物を必ずご確認ください。偽ブランド品や盗品物などの販売は犯罪であり、法律により処罰される可能性があります。また、出品をもちまして加盟店規約に同意したことになります。
+
+  .form__footer
+    .form__footer__content
+      .form__footer__content__main
+        %ul.form__footer__content__main__lists
+          %li.form__footer__content__main__lists__list
+            プライバシーポリシー
+          %li.form__footer__content__main__lists__list
+            フリマ利用規約
+          %li.form__footer__content__main__lists__list
+            特定商取引に関する表記
+        %p.form__footer__copyright
+          © FURIMA 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :items, only: [:index, :new, :create, :show, :edit, :destroy] do
+  resources :items do
     get '/purchase', to: 'items#purchase', as: :purchase
     post '/purchase', to: 'items#pay'
     collection do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,13 +54,6 @@ ActiveRecord::Schema.define(version: 2020_10_01_132448) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
-  create_table "profiles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "nickname"
-    t.string "profile"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "user_addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "first_name", null: false
     t.string "last_name", null: false
@@ -92,8 +85,6 @@ ActiveRecord::Schema.define(version: 2020_10_01_132448) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "credit_cards", "users"

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,16 @@
 FactoryBot.define do
   factory :category do
-    
+    name {"メンズ"}
+    ancestry {nil}
+
+    factory :child_category do |f|
+      f.parent create(:category)
+
+      factory :grand_category do |g|
+        g.parent create(:child_category)
+      end
+
+    end 
+
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,16 +1,15 @@
 FactoryBot.define do
   factory :category do
-    name {"メンズ"}
-    ancestry {nil}
+    # name {"メンズ"}
+    # ancestry {nil}
 
-    factory :child_category do |f|
-      f.parent create(:category)
+    # factory :child_category do |f|
+    #   f.parent create(:category)
 
-      factory :grand_category do |g|
-        g.parent create(:child_category)
-      end
+    #   factory :grand_category do |g|
+    #     g.parent create(:child_category)
+    #   end
 
-    end 
-
+    # end 
   end
 end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :image do
-    
+    image { File.open("#{Rails.root}/public/apple-touch-icon.png") }
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -9,11 +9,10 @@ FactoryBot.define do
     delivery_date_id        {"1"}
     price                   {"500"}
     user
-    after(:build) do |item|
-      # 画像の紐付け
-      item.images << build(:image)
-      # create(:grand_child_category)のfactoryの中で、親の定義、さらに親の定義が始まる。
-      item.category_id = create(:grand_child_category).id
-    end
+    # after(:build) do |item|
+    #   item.images << build(:image)
+    #   # create(:grand_child_category)のfactoryの中で、親の定義、さらに親の定義が始まる。
+    #   item.category_id = create(:grand_child_category).id
+    # end
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,12 +2,18 @@ FactoryBot.define do
   factory :item do
     name                    {"キウイ"}
     describe                {"新鮮なキウイです"}
-    category                {"食品"}
     brand                   {"ゼスプリ"}
     condition_id            {"1"}
     shipping_charge_id      {"1"}
     prefecture_id           {"1"}
     delivery_date_id        {"1"}
     price                   {"500"}
+    user
+    after(:build) do |item|
+      # 画像の紐付け
+      item.images << build(:image)
+      # create(:grand_child_category)のfactoryの中で、親の定義、さらに親の定義が始まる。
+      item.category_id = create(:grand_child_category).id
+    end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -81,4 +81,85 @@ describe Item do
       expect(item.errors[:delivery_date_id]).to include("can't be blank")
     end
   end
+
+  describe '#update' do
+    it "全て入力されていればOK" do
+      item = create(:item)
+      expect(item).to be_valid
+    end
+    it "nameが空ならNG" do
+      item = build(:item, name: nil)
+      item.valid?
+      expect(item.errors[:name]).to include("can't be blank")
+    end
+    it "nameが41文字以上ならNG" do
+      item = build(:item, name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      item.valid?
+      expect(item.errors[:name]).to include("is too long (maximum is 40 characters)")
+    end
+    it "describeが空ならNG" do
+      item = build(:item, describe: nil)
+      item.valid?
+      expect(item.errors[:describe]).to include("can't be blank")
+    end
+    it "describeが1001文字以上ならNG" do
+      item = build(:item, describe: "a" * 1001)
+      item.valid?
+      expect(item.errors[:describe]).to include("is too long (maximum is 1000 characters)")
+    end
+    it "brandが空でもOK" do
+      item = build(:item, brand: "")
+      expect(item).to be_valid
+    end
+    it "priceが空ならNG" do
+      item = build(:item, price: nil)
+      item.valid?
+      expect(item.errors[:price]).to include("can't be blank")
+    end
+    it "priceがinteger以外ならNG" do
+      item = build(:item, price: "３００")
+      item.valid?
+      expect(item.errors[:price]).to include("is not a number")
+    end
+    it "priceが300円未満ならNG" do
+      item = build(:item, price: "290")
+      item.valid?
+      expect(item.errors[:price]).to include("must be greater than or equal to 300")
+    end
+    it "priceが9999999円よりも高額ならNG" do
+      item = build(:item, price: "10000000")
+      item.valid?
+      expect(item.errors[:price]).to include("must be less than or equal to 9999999")
+    end
+    it "categoryが空ならNG" do
+      item = build(:item, category: nil)
+      item.valid?
+      expect(item.errors[:category]).to include("can't be blank")
+    end
+    it "conditionが空ならNG" do
+      item = build(:item, condition_id: nil)
+      item.valid?
+      expect(item.errors[:condition_id]).to include("can't be blank")
+    end
+    it "conditionが空ならNG" do
+      item = build(:item, condition_id: nil)
+      item.valid?
+      expect(item.errors[:condition_id]).to include("can't be blank")
+    end
+    it "shipping_chargeが空ならNG" do
+      item = build(:item, shipping_charge_id: nil)
+      item.valid?
+      expect(item.errors[:shipping_charge_id]).to include("can't be blank")
+    end
+    it "prefectureが空ならNG" do
+      item = build(:item, prefecture_id: nil)
+      item.valid?
+      expect(item.errors[:prefecture_id]).to include("can't be blank")
+    end
+    it "delivery_dateが空ならNG" do
+      item = build(:item, delivery_date_id: nil)
+      item.valid?
+      expect(item.errors[:delivery_date_id]).to include("can't be blank")
+    end
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -51,9 +51,9 @@ describe Item do
       expect(item.errors[:price]).to include("must be less than or equal to 9999999")
     end
     it "categoryが空ならNG" do
-      item = build(:item, category: nil)
+      item = build(:item, category_id: nil)
       item.valid?
-      expect(item.errors[:category]).to include("can't be blank")
+      expect(item.errors[:category_id]).to include("can't be blank")
     end
     it "conditionが空ならNG" do
       item = build(:item, condition_id: nil)
@@ -132,9 +132,9 @@ describe Item do
       expect(item.errors[:price]).to include("must be less than or equal to 9999999")
     end
     it "categoryが空ならNG" do
-      item = build(:item, category: nil)
+      item = build(:item, category_id: nil)
       item.valid?
-      expect(item.errors[:category]).to include("can't be blank")
+      expect(item.errors[:category_id]).to include("can't be blank")
     end
     it "conditionが空ならNG" do
       item = build(:item, condition_id: nil)


### PR DESCRIPTION
# What
出品した商品の情報を編集できるようにする。

# Why
出品した商品について編集機能を実装することでユーザーの使い勝手を向上させるため。

# 参考GIF
・商品編集ページに飛んだ後、何も変更しなかった場合
https://gyazo.com/49317b67df23acfc71fab439e1e83c09
・商品編集ページに飛んだ後、画像とカテゴリを編集した場合
https://gyazo.com/5505aa5bcd4d2f1b06fc2b5b1a3e58e6
・商品編集ページで画像を全て削除した場合
https://gyazo.com/2e9d9ecfbba872767a5ded517dcfc854